### PR TITLE
Refactor controllers and extract auth helpers

### DIFF
--- a/Server/utils/authHelpers.ts
+++ b/Server/utils/authHelpers.ts
@@ -1,0 +1,54 @@
+import User from "../models/User.js";
+import Playlist from "../models/Playlists.js";
+import { DEFAULT_PLAYLISTS_EN, DEFAULT_PLAYLISTS_JP } from "./constants.js";
+
+/** Generate a unique email for demo users. */
+export const generateDemoEmail = (): string => {
+  const timestamp = Date.now();
+  const randomString = Math.random().toString(36).substring(2, 15);
+  return `DemoUser${timestamp}-${randomString}@demo.com`;
+};
+
+export interface CreateUserParams {
+  name: string;
+  email: string;
+  password: string;
+  isDemo: boolean;
+  theme: string;
+  language: string;
+}
+
+/**
+ * Create a user and populate their default playlists.
+ * Returns the created user and JWT token.
+ */
+export const createUserWithPlaylists = async ({
+  name,
+  email,
+  password,
+  isDemo,
+  theme,
+  language,
+}: CreateUserParams) => {
+  const user = await User.create({
+    name,
+    email,
+    password,
+    isDemo,
+    theme,
+    language,
+  });
+
+  const basePlaylists =
+    language === "jp" ? DEFAULT_PLAYLISTS_JP : DEFAULT_PLAYLISTS_EN;
+
+  const playlists = basePlaylists.map((playlist) => ({
+    ...playlist,
+    userID: user._id,
+    isDemoUserPlaylist: isDemo,
+  }));
+
+  await Promise.all(playlists.map((p) => Playlist.create(p)));
+
+  return { user, token: user.createJWT() };
+};


### PR DESCRIPTION
## Summary
- move demo email and playlist helpers to dedicated module
- type Express controllers and add Mongoose generics
- extract sort options constant in animes controller

## Testing
- `npx tsc --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6863fb3bf184832a8f7dc06d75a15e14